### PR TITLE
feat: Increase cost for the purchase of places to 3 points instead of 1

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,8 +8,10 @@ temp.py
 env
 .pytest_cache
 __pycache__
+pytest_report.html
 assets
 .coverage
 htmlcov
 .vscode
 assets
+tests

--- a/models/club_model.py
+++ b/models/club_model.py
@@ -48,7 +48,6 @@ class Club():
         try:
             return int(points)
         except ValueError as e:
-            print('Passed points to club model cannot be converted into int')
             raise e
 
     def serialize_club(self) -> dict:
@@ -63,7 +62,7 @@ class Club():
                 'points': str(self.points)}
         return club
 
-    def has_enough_points(self, places_requested: int) -> bool:
+    def has_enough_points(self, purchase_cost: int) -> bool:
         """
         Check if the number of points avalaible is superior or
         equal to the passed number of places required.
@@ -75,4 +74,4 @@ class Club():
             bool: True if number points is superior or equal to the amount of
             places required, False otherwise.
         """
-        return True if self.points >= places_requested else False
+        return True if self.points >= purchase_cost else False

--- a/services/purchase.py
+++ b/services/purchase.py
@@ -5,6 +5,9 @@ from .competition import CompetitionService
 from .club import ClubService
 
 
+PLACE_COST = 3
+
+
 class PurchaseHandler():
     """
     A class to represent a purchase instance.
@@ -18,13 +21,14 @@ class PurchaseHandler():
             An instance of the CompetitionService class
         club_srv (ClubService):
             An instance of the ClubService class
+        purchase_cost(int): The cost of the requested purchase.
 
     Methods:
         is_valid_places_required(places_required):
             Returns places_required as an integer.
         purchase_places(club, competition):
-            Subtract attributes places_required from passed
-            club points and passed competition number_of_places.
+            Subtract purchase_cost from the points of the passed
+            club and the number_of_places of the passed competition.
         execute_purchase(): Function to execute the purchase process.
         places_required_is_no_more_than_12():
             Check if the amount of places required
@@ -51,9 +55,10 @@ class PurchaseHandler():
         """
         self.club_name = club_name
         self.competition_name = competition_name
-        self.places_required = self.is_valid_places_required(places_required)
         self.club_srv = club_service
         self.comp_srv = comp_service
+        self.places_required = self.is_valid_places_required(places_required)
+        self.purchase_cost = self.places_required * PLACE_COST
 
     def is_valid_places_required(self, places_required: str) -> int:
         """
@@ -76,7 +81,8 @@ class PurchaseHandler():
     def purchase_places(self, club: Club,
                         competition: Competition) -> tuple[Club, Competition]:
         """
-        Subtract attributes places_required from passed club and competition.
+        Subtract purchase_cost from the points of the passed
+        club and the number_of_places of the passed competition.
 
         Args:
             club (Club): The club requesting the purchase.
@@ -87,8 +93,8 @@ class PurchaseHandler():
         Returns:
             tuple: club, competition as Club, Competition objects
         """
-        competition.number_of_places -= self.places_required
-        club.points -= self.places_required
+        competition.number_of_places -= self.purchase_cost
+        club.points -= self.purchase_cost
         return club, competition
 
     def execute_purchase(self) -> dict:
@@ -152,6 +158,6 @@ class PurchaseHandler():
                      and competition.date_has_not_passed()
                      and competition.has_enough_places(self.places_required)
                      and self.places_required_is_no_more_than_12()
-                     and club.has_enough_points(self.places_required))
+                     and club.has_enough_points(self.purchase_cost))
                     else False)
         return is_valid


### PR DESCRIPTION

This increase the cost for purchasing a places in a competitions to 3 club points, was previously 3.

### CHANGES

**In purchase.py:**
- Added a global variable _PLACE_COST_ to set up the cost of a place.
- Added an attribute _purchase_cost_ to the _PurchaseHandler_ class. It is the _places_required_ multiplied by the cost of a place.
- Attribute _purchase_cost_ is used in method _execute_purchase_ as the value to substract to the club points. The method used the _places_required_ attribute previously, since it was 1:1.

